### PR TITLE
Removed the token part after displaying result

### DIFF
--- a/script.js
+++ b/script.js
@@ -175,6 +175,11 @@ function displayResults(connections, failedUsernames) {
     tableHTML += '</table>';
     connectionsTableDiv.innerHTML = tableHTML;
 
+    // Hide the token input field, label, and analyze button
+    tokenInput.style.display = 'none';
+    document.querySelector('label[for="token"]').style.display = 'none';
+    analyzeButton.style.display = 'none';
+
     // Show the button container and the buttons
     buttonContainer.style.display = 'flex';
     copyResultsButton.style.display = 'inline-block';
@@ -193,6 +198,7 @@ function displayResults(connections, failedUsernames) {
         failedUsernamesDiv.style.display = 'none';
     }
 }
+
 
 /**
  * Copy the results table to the clipboard


### PR DESCRIPTION
After the results were displayed, once could still see the GitHub Access token part, have removed it now, to make the result look neat.
Here's how it looks like 👇 
<img width="1297" alt="Screenshot 2024-08-31 at 7 42 26 PM" src="https://github.com/user-attachments/assets/5f48856e-1b5a-474a-824d-3bea9cff7daa">
