### PR TITLE
github api optimization

### DIFF
--- a/script.js
+++ b/script.js
@@ -96,7 +96,7 @@ async function analyzeConnections() {
     // Convert all input usernames to lowercase for case-insensitive comparison
     const lowercaseUsernames = usernames.map(username => username.toLowerCase());
 
-    const [userInfoData, followingData] = await getUserInfoAndFollowing(usernames, token).catch(error => {
+    const [userInfoData, followingData] = await getUserInfoAndFollowing(lowercaseUsernames, token).catch(error => {
         console.error('Error fetching data:', error);
     });
     for (const username of usernames) {
@@ -244,7 +244,7 @@ async function getUserInfoAndFollowing(usernames, token) {
     const userInfo = {};
     for (const userData of Object.values(initialData)) {
         console.log(userData);
-        userInfo[userData.login] = getUserInfo(userData);
+        userInfo[userData.login.toLowerCase()] = getUserInfo(userData);
     }
 
     const followingData = {};


### PR DESCRIPTION
Instead of making `n` GitHub API calls, make just 1 call to the GitHub GraphQL API. We only make additional API calls for users who follow 100+ accounts.

## Why does this matter?
1. Making separate API calls for each user takes a lot of time. Making a single API call to get the data of most users and only making additional calls for users who follow 100+ users reduces the processing time by an order of magnitude.
2. By reducing the number of API calls, we also solve the GitHub API rate limiting issue.